### PR TITLE
Fix version embedding

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,6 +7,8 @@ on:
 jobs:
   publish-dist:
     runs-on: ubuntu-latest
+    env:
+      DRONE_TAG: ${{github.ref_name}}
     steps:
       - uses: actions/checkout@v2
       - name: build

--- a/pkg/rancherd/rancher.go
+++ b/pkg/rancherd/rancher.go
@@ -9,8 +9,8 @@ import (
 
 	"github.com/rancher/rancherd/pkg/config"
 	"github.com/rancher/rancherd/pkg/plan"
+	"github.com/rancher/rancherd/pkg/version"
 	"github.com/rancher/rancherd/pkg/versions"
-	"github.com/rancher/system-agent/pkg/version"
 	"github.com/sirupsen/logrus"
 	"sigs.k8s.io/yaml"
 )

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,4 +1,4 @@
-package versions
+package version
 
 import (
 	"fmt"


### PR DESCRIPTION
- Export Github ref_name to DRONE_TAG variable. So when tagging we can embed the tag into code. Let's keep drone compatibility.
- Fix the [wrong `version` package import](https://github.com/harvester/rancherd/blob/67225491d13a56c5e95493c13b07f84bb3f98a5e/pkg/rancherd/rancher.go#L13) for the [`FriendlyVersion()` call](https://github.com/harvester/rancherd/blob/67225491d13a56c5e95493c13b07f84bb3f98a5e/pkg/rancherd/rancher.go#L56). 

### How to test

*Normal build*
```
$ make
$ bin/rancherd info
    Rancher:
    Kubernetes:
    Rancherd:   4f3f1ae (4f3f1ae)
```

*Tagged build*
```
$ DRONE_TAG=v0.0.1-alpha13-harvester1 make
$ bin/rancherd info
bin/rancherd info                                                                                                                                                                    1 ↵
    Rancher:
    Kubernetes:
    Rancherd:   v0.0.1-alpha13-harvester1 (4f3f1ae)
```